### PR TITLE
Do not drop real inner-fragment bonds for collapsed CDXML fragments

### DIFF
--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -495,43 +495,13 @@ void MoleculeCdxmlLoader::_parseCollections(BaseMolecule& mol)
         }
     }
 
-    // Build a set of inner node IDs for each fragment node so we can
-    // identify bonds that are entirely internal to a collapsed fragment.
-    std::unordered_set<int> all_inner_node_ids;
-    for (auto fidx : _fragment_nodes)
-    {
-        auto& frag_node = nodes[fidx];
-        // Exclude ExternalConnectionPoint nodes — their bonds bridge the
-        // inner fragment to the outer molecule and must be preserved.
-        std::unordered_set<int> ext_conn_ids(frag_node.ext_connections.begin(), frag_node.ext_connections.end());
-        for (auto inner_id : frag_node.inner_nodes)
-        {
-            if (ext_conn_ids.count(inner_id) == 0)
-                all_inner_node_ids.insert(inner_id);
-        }
-    }
-
-    // Filter out bonds where both endpoints are inner nodes of a collapsed
-    // fragment. These bonds are zero-length (all inner atoms share the parent
-    // node's position) and keeping them skews Ketcher's average-bond-length
-    // calculation, causing incorrect scale.
-    std::vector<CdxmlBond> filtered_bonds;
     for (const auto& bond : bonds)
-    {
-        bool first_inner = all_inner_node_ids.count(bond.be.first) > 0;
-        bool second_inner = all_inner_node_ids.count(bond.be.second) > 0;
-        if (first_inner && second_inner)
-            continue;
-        filtered_bonds.push_back(bond);
-    }
-
-    for (const auto& bond : filtered_bonds)
     {
         _checkFragmentConnection(bond.be.first, bond.id);
         _checkFragmentConnection(bond.be.second, bond.id);
     }
 
-    _addAtomsAndBonds(mol, atoms, filtered_bonds);
+    _addAtomsAndBonds(mol, atoms, bonds);
 
     _processEnhancedStereo(mol);
 


### PR DESCRIPTION
Fixes the chemistry regression in MAT-72091. The inner-fragment bond filter (#18, narrowed in #19) drops every bond whose endpoints are both inner nodes of a collapsed fragment — including real chemical bonds like the B–OH bonds inside a B(OH)₂ substituent. The loaded molecule loses connectivity and computes the wrong formula.

Verified against the attached `phenylboronic acid` CDXML:
- unc-18: C6H7BO2, MW 121.93 (correct)
- unc-21 (#19): C6H11BO2, MW 125.96 (the wrong value Chan reported)

The filter only existed to stop zero-length inner bonds (a side effect of #17 collapsing all inner atoms onto the parent node's position) from skewing Ketcher's average-bond-length scaling — a cosmetic concern. Deleting real bonds to fix display scale is wrong. This reverts the filter and keeps #17's position collapse, which is what actually fixes the MAT-69846 text distortion.

If the average-bond-length scaling resurfaces, it should be handled in the scale calculation (exclude collapsed-fragment bonds from the average) rather than by removing bonds from the molecule.

## Test plan
- Build wheels/image, cut a new `unc-22` tag.
- Paste the `phenylboronic acid` CDXML into a reaction table; confirm B(OH)₂ stays bonded to the ring, name resolves, and MW = 121.93.
- Re-check the MAT-69846 text-distortion case to confirm it is still fixed.