### PR TITLE
Fix SDF export crash for reactions [MAT-73021]

### DIFF
--- a/utils/indigo-service/backend/service/v2/indigo_api.py
+++ b/utils/indigo-service/backend/service/v2/indigo_api.py
@@ -474,8 +474,12 @@ def save_moldata(
     elif output_format == "chemical/x-sdf":
         buffer = indigo.writeBuffer()
         sdfSaver = indigo.createSaver(buffer, "sdf")
-        for frag in md.struct.iterateComponents():
-            sdfSaver.append(frag.clone())
+        if md.is_rxn:
+            for mol in md.struct.iterateMolecules():
+                sdfSaver.append(mol.clone())
+        else:
+            for frag in md.struct.iterateComponents():
+                sdfSaver.append(frag.clone())
         sdfSaver.close()
         return buffer.toString()
     elif output_format == "chemical/x-rdf":


### PR DESCRIPTION
## Description

Fixes the `IndigoException: core: <reaction> is not a base molecule` crash when exporting a structure to SDF while a reaction is on the canvas (e.g. Ketcher's Save Structure → SDF).

The `/convert` handler's `chemical/x-sdf` branch in `save_moldata` called `md.struct.iterateComponents()`, a molecule-only operation that throws on any reaction (in every Indigo version — this is service-side, not a core/`.so` issue). For reactions, iterate the reaction's molecules and concatenate them into the SDF (`$$$$`-delimited); plain molecules keep the existing `iterateComponents()` path.

- JIRA Ticket: [MAT-73021](https://uncount.atlassian.net/browse/MAT-73021)

## What did I (author) test?

Built an overlay `indigo-server` image on the current production base (`indigo-server:1.28.0-rc.3-unc-22`) with this patch and ran it locally. In the Ketcher UI, exporting a reaction to SDF V2000 now succeeds — it returns a `$$$$`-delimited SDF of the reaction's component molecules instead of erroring. Plain-molecule → SDF export is unchanged.

## Testing recommendations and risks (for reviewers)

- Low risk: only a new `if md.is_rxn` branch is added; the existing molecule path (`iterateComponents`) is untouched.
- Please confirm plain-molecule → SDF export still behaves as before.
- **Deploy note:** this is the fork's first change to indigo-service Python code. The production image build (`main` `deploy/kube/indigo/Dockerfile.build`) currently copies only the built `*.so` + conf files, **not** the service code — it must also `COPY` this `indigo_api.py` into `/srv/api/v2/` for the fix to reach production.

## Screenshots

N/A (backend service change)


[MAT-73021]: https://uncount.atlassian.net/browse/MAT-73021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ