### PR TITLE
CIP: label AND-group stereocenters RS (MAT-75502)

### DIFF
--- a/core/indigo-core/molecule/molecule_cip_calculator.h
+++ b/core/indigo-core/molecule/molecule_cip_calculator.h
@@ -83,9 +83,8 @@ namespace indigo
         void removeCIPSgroups(BaseMolecule& mol);
         void convertSGroupsToCIP(BaseMolecule& mol);
 
-        const std::unordered_map<std::string, CIPDesc> KSGroupToCIP = {{"(R)", CIPDesc::R}, {"(S)", CIPDesc::S},   {"(r)", CIPDesc::r},
-                                                                       {"(s)", CIPDesc::s}, {"(RS)", CIPDesc::RS}, {"(E)", CIPDesc::E},
-                                                                       {"(Z)", CIPDesc::Z}};
+        const std::unordered_map<std::string, CIPDesc> KSGroupToCIP = {{"(R)", CIPDesc::R},   {"(S)", CIPDesc::S}, {"(r)", CIPDesc::r}, {"(s)", CIPDesc::s},
+                                                                       {"(RS)", CIPDesc::RS}, {"(E)", CIPDesc::E}, {"(Z)", CIPDesc::Z}};
 
     private:
         void _calcRSStereoDescriptor(BaseMolecule& mol, BaseMolecule& unfolded_h_mol, int idx, Array<CIPDesc>& atom_cip_desc, Array<int>& stereo_passed,

--- a/core/indigo-core/molecule/molecule_cip_calculator.h
+++ b/core/indigo-core/molecule/molecule_cip_calculator.h
@@ -44,7 +44,8 @@ namespace indigo
         S,
         R,
         E,
-        Z
+        Z,
+        RS
     };
 
     struct CIPContext
@@ -82,8 +83,9 @@ namespace indigo
         void removeCIPSgroups(BaseMolecule& mol);
         void convertSGroupsToCIP(BaseMolecule& mol);
 
-        const std::unordered_map<std::string, CIPDesc> KSGroupToCIP = {{"(R)", CIPDesc::R}, {"(S)", CIPDesc::S}, {"(r)", CIPDesc::r},
-                                                                       {"(s)", CIPDesc::s}, {"(E)", CIPDesc::E}, {"(Z)", CIPDesc::Z}};
+        const std::unordered_map<std::string, CIPDesc> KSGroupToCIP = {{"(R)", CIPDesc::R}, {"(S)", CIPDesc::S},   {"(r)", CIPDesc::r},
+                                                                       {"(s)", CIPDesc::s}, {"(RS)", CIPDesc::RS}, {"(E)", CIPDesc::E},
+                                                                       {"(Z)", CIPDesc::Z}};
 
     private:
         void _calcRSStereoDescriptor(BaseMolecule& mol, BaseMolecule& unfolded_h_mol, int idx, Array<CIPDesc>& atom_cip_desc, Array<int>& stereo_passed,

--- a/core/indigo-core/molecule/src/meta_commons.cpp
+++ b/core/indigo-core/molecule/src/meta_commons.cpp
@@ -63,8 +63,8 @@ namespace indigo
 
     CIPDesc stringToCIP(const std::string& cip_str)
     {
-        static const std::unordered_map<std::string, CIPDesc> KStringToCIP = {{"R", CIPDesc::R}, {"S", CIPDesc::S}, {"r", CIPDesc::r},
-                                                                              {"s", CIPDesc::s}, {"E", CIPDesc::E}, {"Z", CIPDesc::Z}};
+        static const std::unordered_map<std::string, CIPDesc> KStringToCIP = {{"R", CIPDesc::R}, {"S", CIPDesc::S},   {"r", CIPDesc::r}, {"s", CIPDesc::s},
+                                                                              {"E", CIPDesc::E}, {"RS", CIPDesc::RS}, {"Z", CIPDesc::Z}};
         auto cip_it = KStringToCIP.find(cip_str);
         if (cip_it != KStringToCIP.end())
             return cip_it->second;
@@ -73,8 +73,9 @@ namespace indigo
 
     std::string CIPToString(CIPDesc cip)
     {
-        static const std::unordered_map<int, std::string> KCIPToString = {{(int)CIPDesc::R, "R"}, {(int)CIPDesc::S, "S"}, {(int)CIPDesc::r, "r"},
-                                                                          {(int)CIPDesc::s, "s"}, {(int)CIPDesc::E, "E"}, {(int)CIPDesc::Z, "Z"}};
+        static const std::unordered_map<int, std::string> KCIPToString = {{(int)CIPDesc::R, "R"}, {(int)CIPDesc::S, "S"},   {(int)CIPDesc::r, "r"},
+                                                                          {(int)CIPDesc::s, "s"}, {(int)CIPDesc::RS, "RS"}, {(int)CIPDesc::E, "E"},
+                                                                          {(int)CIPDesc::Z, "Z"}};
         auto cip_it = KCIPToString.find((int)cip);
         std::string res;
         if (cip_it != KCIPToString.end())

--- a/core/indigo-core/molecule/src/molecule_cip_calculator.cpp
+++ b/core/indigo-core/molecule/src/molecule_cip_calculator.cpp
@@ -159,8 +159,6 @@ bool MoleculeCIPCalculator::addCIPStereoDescriptors(BaseMolecule& mol)
         CIPDesc desc = atom_cip_desc[atom_idx];
         if (desc > CIPDesc::UNKNOWN)
         {
-            // An "&" (AND) group center is racemic: both enantiomers are present, so a true R/S
-            // center is both R and S. Report RS. Pseudoasymmetric r/s is reflection-invariant: keep it.
             if ((desc == CIPDesc::R || desc == CIPDesc::S) && mol.stereocenters.getType(atom_idx) == MoleculeStereocenters::ATOM_AND)
                 desc = CIPDesc::RS;
             mol._cip_atoms.insert(atom_idx, desc);

--- a/core/indigo-core/molecule/src/molecule_cip_calculator.cpp
+++ b/core/indigo-core/molecule/src/molecule_cip_calculator.cpp
@@ -156,8 +156,15 @@ bool MoleculeCIPCalculator::addCIPStereoDescriptors(BaseMolecule& mol)
 
     for (atom_idx = 0; atom_idx < atom_cip_desc.size(); ++atom_idx)
     {
-        if (atom_cip_desc[atom_idx] > CIPDesc::UNKNOWN)
-            mol._cip_atoms.insert(atom_idx, atom_cip_desc[atom_idx]);
+        CIPDesc desc = atom_cip_desc[atom_idx];
+        if (desc > CIPDesc::UNKNOWN)
+        {
+            // An "&" (AND) group center is racemic: both enantiomers are present, so a true R/S
+            // center is both R and S. Report RS. Pseudoasymmetric r/s is reflection-invariant: keep it.
+            if ((desc == CIPDesc::R || desc == CIPDesc::S) && mol.stereocenters.getType(atom_idx) == MoleculeStereocenters::ATOM_AND)
+                desc = CIPDesc::RS;
+            mol._cip_atoms.insert(atom_idx, desc);
+        }
     }
 
     for (auto bond_idx = 0; bond_idx < bond_cip_desc.size(); ++bond_idx)
@@ -202,6 +209,9 @@ void MoleculeCIPCalculator::addCIPSgroups(BaseMolecule& mol)
             break;
         case CIPDesc::s:
             sgroup.data.readString("(s)", true);
+            break;
+        case CIPDesc::RS:
+            sgroup.data.readString("(RS)", true);
             break;
         }
 
@@ -270,6 +280,7 @@ void MoleculeCIPCalculator::convertSGroupsToCIP(BaseMolecule& mol)
                     case CIPDesc::r:
                     case CIPDesc::S:
                     case CIPDesc::R:
+                    case CIPDesc::RS:
                         // atoms
                         for (auto atom_idx : dsg.atoms)
                             mol.setAtomCIP(atom_idx, cip_it->second);


### PR DESCRIPTION
Calculate CIP now outputs `RS` for a stereocenter in an `&` (AND) group that resolves to a true R/S center, since the racemic mixture contains both enantiomers; ABS centers and pseudoasymmetric `r`/`s` keep their single label.

MAT-75502

Test plan: Calculate CIP on a structure with an `&1` AND group containing stereocenters → expect `RS`; ABS centers still show `R`/`S`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
