### PR TITLE
MAT-77592 – Preserve collapsed CDXML fragment inner bonds (benzene nickname → methane)

### DIFF
--- a/api/tests/integration/ref/formats/cdxml_nickname.py.out
+++ b/api/tests/integration/ref/formats/cdxml_nickname.py.out
@@ -1,0 +1,3 @@
+*** CDXML collapsed nickname fragments ***
+Benzene.cdxml
+  component 0: atoms=6 bonds=6 formula=C6 H6

--- a/api/tests/integration/tests/formats/cdxml_nickname.py
+++ b/api/tests/integration/tests/formats/cdxml_nickname.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.append(
+    os.path.normpath(
+        os.path.join(os.path.abspath(__file__), "..", "..", "..", "common")
+    )
+)
+from env_indigo import *  # noqa
+
+indigo = Indigo()
+indigo.setOption("molfile-saving-skip-date", True)
+indigo.setOption("json-saving-pretty", True)
+
+# Collapsed CDXML "nickname" fragments carry the real molecule inside an inner
+# <fragment>. Their inner bonds (e.g. the benzene ring, or B-OH inside a B(OH)2
+# substituent) must be preserved on load; dropping them corrupted the structure
+# (benzene loaded as methane, phenylboronic acid as C6H11BO2). See MAT-77592.
+print("*** CDXML collapsed nickname fragments ***")
+
+root = joinPathPy("molecules/cdxml_nickname", __file__)
+for filename in sorted(os.listdir(root)):
+    print(filename)
+    obj = None
+    is_reaction = False
+    for loader, as_reaction in (
+        (indigo.loadMoleculeFromFile, False),
+        (indigo.loadReactionFromFile, True),
+    ):
+        try:
+            obj = loader(os.path.join(root, filename))
+            is_reaction = as_reaction
+            break
+        except IndigoException as e:
+            last = e
+    if obj is None:
+        print("  load failed:", getIndigoExceptionText(last))
+        continue
+    mols = list(obj.iterateMolecules()) if is_reaction else [obj]
+    for i, mol in enumerate(mols):
+        print(
+            "  component %d: atoms=%d bonds=%d formula=%s"
+            % (i, mol.countAtoms(), mol.countBonds(), mol.grossFormula())
+        )

--- a/api/tests/integration/tests/formats/molecules/cdxml_nickname/Benzene.cdxml
+++ b/api/tests/integration/tests/formats/molecules/cdxml_nickname/Benzene.cdxml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE CDXML SYSTEM "https://static.chemistry.revvitycloud.com/cdxml/CDXML.dtd" >
+<CDXML
+ CreationProgram="ChemDraw 25.5.0.6237"
+ Name="Benzene.cdxml"
+ BoundingBox="207.73 109.84 246.06 117.12"
+ WindowPosition="0 0"
+ WindowSize="0 0"
+ FractionalWidths="yes"
+ InterpretChemically="yes"
+ ShowAtomQuery="yes"
+ ShowAtomStereo="no"
+ ShowAtomEnhancedStereo="yes"
+ ShowAtomNumber="no"
+ ShowResidueID="no"
+ ShowBondQuery="yes"
+ ShowBondRxn="yes"
+ ShowBondStereo="no"
+ ShowTerminalCarbonLabels="no"
+ ShowNonTerminalCarbonLabels="no"
+ HideImplicitHydrogens="no"
+ LabelFont="60"
+ LabelSize="10"
+ LabelFace="96"
+ CaptionFont="60"
+ CaptionSize="10"
+ HashSpacing="2.49"
+ MarginWidth="1.59"
+ LineWidth="0.60"
+ BoldWidth="2.01"
+ BondLength="14.40"
+ BondSpacing="18"
+ ChainAngle="120"
+ LabelJustification="Auto"
+ CaptionJustification="Left"
+ AminoAcidTermini="HOH"
+ ShowSequenceTermini="yes"
+ ShowSequenceBonds="yes"
+ ShowSequenceUnlinkedBranches="no"
+ ShowPrimeLabels="no"
+ ResidueWrapCount="40"
+ PrintMargins="36 36 36 36"
+ MacPrintInfo="00030000004800480000000002DE0240FFEEFFEE030602520367052803FC00020000004800480000000002DE0240000100000064000000010001010100000001270F000100010000000000000000000000000002001901900000000000400000000000000000000100000000000000000000000000000000"
+ ChemPropName=""
+ ChemPropFormula="Chemical formula: "
+ ChemPropExactMass="Exact mass: "
+ ChemPropMolWt="Molecular weight: "
+ ChemPropMOverZ="m/z: "
+ ChemPropAnalysis="Elemental analysis: "
+ ChemPropBoilingPt="Boiling point: "
+ ChemPropMeltingPt="Melting point: "
+ ChemPropCritTemp="Critical temp: "
+ ChemPropCritPres="Critical pres: "
+ ChemPropCritVol="Critical vol: "
+ ChemPropGibbs="Gibbs energy: "
+ ChemPropLogP="Log P: "
+ ChemPropMR="MR: "
+ ChemPropHenry="Henry&apos;s law: "
+ ChemPropEForm="Heat of form: "
+ ChemProptPSA="tPSA: "
+ ChemPropID=""
+ ChemPropFragmentLabel=""
+ color="0"
+ bgcolor="1"
+ RxnAutonumberStart="1"
+ RxnAutonumberConditions="no"
+ RxnAutonumberStyle="Roman"
+ RxnAutonumberFormat="(#)"
+ MonomerRenderingStyle="graphic"
+><colortable>
+<color r="1" g="1" b="1"/>
+<color r="0" g="0" b="0"/>
+<color r="1" g="0" b="0"/>
+<color r="1" g="1" b="0"/>
+<color r="0" g="1" b="0"/>
+<color r="0" g="1" b="1"/>
+<color r="0" g="0" b="1"/>
+<color r="1" g="0" b="1"/>
+</colortable><fonttable>
+<font id="60" charset="x-mac-roman" name="Arial"/>
+</fonttable><page
+ id="53"
+ BoundingBox="0 0 540 720"
+ HeaderPosition="36"
+ FooterPosition="36"
+ PrintTrimMarks="yes"
+ HeightPages="1"
+ WidthPages="1"
+><fragment
+ id="49"
+ BoundingBox="207.73 109.84 246.06 117.12"
+ Z="43"
+><n
+ id="48"
+ p="210.33 113.42"
+ Z="42"
+ NodeType="Nickname"
+ NeedsClean="yes"
+ AS="N"
+ AtomID="1"
+><fragment
+ id="54"
+><n
+ id="55"
+ p="270.04 322.37"
+/><n
+ id="56"
+ p="282.47 329.55"
+/><n
+ id="57"
+ p="294.90 322.37"
+/><n
+ id="58"
+ p="294.90 308.02"
+/><n
+ id="59"
+ p="282.47 300.85"
+/><n
+ id="60"
+ p="270.04 308.02"
+/><b
+ id="61"
+ B="60"
+ E="55"
+/><b
+ id="62"
+ B="59"
+ E="60"
+ Order="2"
+/><b
+ id="63"
+ B="58"
+ E="59"
+/><b
+ id="64"
+ B="57"
+ E="58"
+ Order="2"
+/><b
+ id="65"
+ B="56"
+ E="57"
+/><b
+ id="66"
+ B="55"
+ E="56"
+ Order="2"
+/></fragment><t
+ id="47"
+ p="207 117"
+ BoundingBox="207.73 109.84 246.06 117.12"
+ Z="41"
+ LabelJustification="Left"
+ LabelLineHeight="auto"
+ LineHeight="auto"
+ LabelAlignment="Left"
+><s font="60" size="10" color="0">Benzene</s></t></n></fragment></page></CDXML>

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -571,44 +571,22 @@ void MoleculeCdxmlLoader::_parseCollections(BaseMolecule& mol)
         }
     }
 
-    // Build a set of inner node IDs for fragment nodes where internal collapsed
-    // bonds should be filtered. For fragments connected to the outer molecule,
-    // preserve all internal bonds so chemistry remains intact.
-    std::unordered_set<int> all_inner_node_ids;
-    for (auto fidx : _fragment_nodes)
-    {
-        auto& frag_node = nodes[fidx];
-
-        // Connected fragments (via ExternalConnectionPoint) encode real
-        // substituent structure, so dropping their inner bonds breaks valence.
-        if (!frag_node.ext_connections.empty())
-            continue;
-
-        for (auto inner_id : frag_node.inner_nodes)
-            all_inner_node_ids.insert(inner_id);
-    }
-
-    // Filter out bonds where both endpoints are inner nodes of a collapsed
-    // fragment. These bonds are zero-length (all inner atoms share the parent
-    // node's position) and keeping them skews Ketcher's average-bond-length
-    // calculation, causing incorrect scale.
-    std::vector<CdxmlBond> filtered_bonds;
+    // Do not drop inner bonds of collapsed fragments. Position collapse puts
+    // every inner atom on the parent node's page position, which makes these
+    // bonds zero-length; an earlier filter deleted them to avoid skewing
+    // Ketcher's average-bond-length scaling. But those are real chemical bonds
+    // (e.g. the benzene ring inside a "Benzene" nickname, or B-OH inside a
+    // B(OH)2 substituent), so dropping them corrupts the molecule — benzene
+    // loads as methane, phenylboronic acid as C6H11BO2 instead of C6H7BO2.
+    // The scaling skew is cosmetic and the position collapse already handles
+    // the text distortion; data integrity wins, so keep every bond.
     for (const auto& bond : bonds)
-    {
-        bool first_inner = all_inner_node_ids.count(bond.be.first) > 0;
-        bool second_inner = all_inner_node_ids.count(bond.be.second) > 0;
-        if (first_inner && second_inner)
-            continue;
-        filtered_bonds.push_back(bond);
-    }
-
-    for (const auto& bond : filtered_bonds)
     {
         _checkFragmentConnection(bond.be.first, bond.id);
         _checkFragmentConnection(bond.be.second, bond.id);
     }
 
-    _addAtomsAndBonds(mol, atoms, filtered_bonds);
+    _addAtomsAndBonds(mol, atoms, bonds);
 
     _processEnhancedStereo(mol);
 


### PR DESCRIPTION
## Problem

A collapsed CDXML **nickname** (e.g. the ticket's `Benzene.cdxml`) imported into the reaction table as **methane**. Collapsed `nickname`/`Fragment` nodes hold the real molecule in an inner `<fragment>`; the inner-bond filter in `_parseCollections` dropped every bond whose endpoints are both inner nodes of a collapsed fragment. Those are real chemical bonds, so:

- standalone **Benzene** nickname → 6 disconnected carbons (`C6H24`, 0 bonds) → rendered as methane (**MAT-77592**)
- phenylboronic acid **B(OH)₂** → `C6H11BO2` instead of `C6H7BO2`

## Fix

Remove the inner-bond filter and keep every bond. The filter only existed to stop zero-length inner bonds (a side effect of the fragment position-collapse) from skewing Ketcher's average-bond-length scaling — cosmetic, and already handled by the position collapse. Data integrity wins.

## Verification (local build, before → after)

| | before | after |
|---|---|---|
| Benzene nickname | `C6H24`, 0 bonds → methane | `C6H6`, 6 bonds ✓ |
| B(OH)₂ on phenyl | `C6H11BO2` | `C6H7BO2` ✓ |

`formats/cdxml_nickname` (new, deterministic regression test using the public `Benzene.cdxml`) → **PASSED**.

## Notes

- `ref/formats/cdx_to_ket.py.out` / `cdxml_to_mol.py.out` legitimately gain bonds from this fix and should be regenerated in the canonical CI env (not done here — local float formatting for coordinates differs from CI).
- Long-term, the position-collapse → zero-length-bond tension is best removed by the epam-mimicking collapsed-fragment rewrite (MAT-77457).

🤖 Generated with [Claude Code](https://claude.com/claude-code)