### PR TITLE
MAT-77592 – Anchor collapsed CDXML fragment geometry (fix nickname render)

### DIFF
--- a/api/tests/integration/ref/formats/cdxml_nickname.py.out
+++ b/api/tests/integration/ref/formats/cdxml_nickname.py.out
@@ -1,3 +1,3 @@
 *** CDXML collapsed nickname fragments ***
 Benzene.cdxml
-  component 0: atoms=6 bonds=6 formula=C6 H6
+  component 0: atoms=6 bonds=6 formula=C6 H6 distinct_positions=6

--- a/api/tests/integration/tests/formats/cdxml_nickname.py
+++ b/api/tests/integration/tests/formats/cdxml_nickname.py
@@ -38,7 +38,23 @@ for filename in sorted(os.listdir(root)):
         continue
     mols = list(obj.iterateMolecules()) if is_reaction else [obj]
     for i, mol in enumerate(mols):
+        # Distinct atom positions guard against the collapsed-fragment bug:
+        # inner atoms of a collapsed nickname must keep their real geometry,
+        # not all land on the parent node's point (which rendered as an empty
+        # box). "collapsed" means every atom shares one coordinate.
+        pts = {
+            (round(a.xyz()[0], 3), round(a.xyz()[1], 3))
+            for a in mol.iterateAtoms()
+        }
+        collapsed = mol.countAtoms() > 1 and len(pts) == 1
         print(
-            "  component %d: atoms=%d bonds=%d formula=%s"
-            % (i, mol.countAtoms(), mol.countBonds(), mol.grossFormula())
+            "  component %d: atoms=%d bonds=%d formula=%s distinct_positions=%d%s"
+            % (
+                i,
+                mol.countAtoms(),
+                mol.countBonds(),
+                mol.grossFormula(),
+                len(pts),
+                " COLLAPSED!" if collapsed else "",
+            )
         )

--- a/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
+++ b/core/indigo-core/molecule/src/molecule_cdxml_loader.cpp
@@ -841,13 +841,27 @@ void MoleculeCdxmlLoader::_parseCDXMLElements(BaseCDXElement& first_elem, bool n
             _parseCDXMLElements(*elem.firstChildElement(), false, true);
             auto inner_idx_end = nodes.size();
             CdxmlNode& fragment_node = nodes[inner_idx_start - 1];
+            // Inner atom coords are from the hidden/expanded structure, in a
+            // different origin than the page. Anchor the fragment at the parent
+            // node's page position while PRESERVING its relative geometry: shift
+            // every inner atom by (parent - inner centroid). Collapsing them all
+            // onto the parent point (the old behavior) destroyed the shape, so a
+            // collapsed "Benzene" nickname became six coincident atoms that
+            // Ketcher could not lay out (rendered as an empty box). Translating
+            // keeps the real hexagon and still anchors it where the nickname sits.
+            Vec3f centroid;
+            const auto inner_count = inner_idx_end - inner_idx_start;
+            for (auto i = inner_idx_start; i < inner_idx_end; ++i)
+                centroid.add(nodes[i].pos);
+            if (inner_count > 0)
+                centroid.scale(1.0f / static_cast<float>(inner_count));
+            Vec3f offset;
+            offset.diff(fragment_node.pos, centroid);
             for (auto i = inner_idx_start; i < inner_idx_end; ++i)
             {
                 auto it = std::upper_bound(fragment_node.inner_nodes.cbegin(), fragment_node.inner_nodes.cend(), fragment_node.id,
                                            [](int a, int b) { return a > b; });
-                // Inner atom coords are from the hidden/expanded structure in an unrelated coordinate space.
-                // Always use the parent node's page position for all inner atoms.
-                nodes[i].pos = fragment_node.pos;
+                nodes[i].pos.add(offset);
                 fragment_node.inner_nodes.insert(it, nodes[i].id);
             }
         }


### PR DESCRIPTION
## Why

Follow-up to #29 (which stopped the benzene nickname importing as *methane*). After that fix the chemistry was right (`C6H6`) but a **standalone nickname still rendered as an empty box** in the reaction table: `#17`'s position-collapse forced all inner atoms of a collapsed fragment onto the parent node's single point, so benzene became 6 *coincident* atoms with zero-length bonds — impossible for Ketcher to lay out.

## Fix

Instead of collapsing every inner atom to one point, **translate** the inner fragment by `(parent position − inner centroid)`. This still anchors the fragment where the nickname sits on the page (the reason `#17` existed — avoid drift) but **preserves its real relative geometry**, so benzene keeps its hexagon.

## Verified (local build)

- Benzene nickname → `C6H6`, 6 bonds, **6 distinct atom positions** (bbox ≈ 0.83×0.96) — was 6 atoms on one point.
- B(OH)₂ and the other reagents in the Suzuki/Buchwald test file keep correct formula + geometry.
- `formats/cdxml_nickname` strengthened to assert distinct atom positions (catches a future re-collapse).

## Reviewer note

This modifies the `#17` position-collapse that was added for fragment drift/scale distortion (INC-198). Translating anchors the fragment at the correct spot *and* keeps geometry, so it should address drift at least as well as collapse did — but it wants a real reaction-table check, and there's a residual risk if any CDXML stores inner-fragment coords at a different *scale* than the page (benzene's matched). Best validated by building the `unc-30` image and importing in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)